### PR TITLE
Enabled Docker Image of the Server to be built.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,30 @@
+###########################################################
+# This Dockerfile allows for the creation of an APEL Server 
+# Docker Image with support for Cloud Accounting
+#
+# A deployed Docker instance will require an instance of
+# the APEL Cloud Accounting Database and the mounting of: 
+#
+# - a cron job under /etc/cron.d to run
+#   /usr/bin/run_cloud_summariser.sh (at least) daily 
+# - APEL Cloud configuration files under /etc/apel
+#
+# and the optional mounting of:
+#
+# - a host direcotry under /var/spool/apel/cloud
+#   to persistantly store messages
+# - a MySQL configuraiton file under /etc/mysql
+#   (to allow command line access to the MySQL database
+#   from within the container.)
+#
+# It has been placed in the repository root to allow for future
+# docker images to built 'commit by commit' from the exact
+# state of the source in the repository. At the moment, it is 
+# limited to tagged versions that have RPMs, as that is the 
+# only way to install APEL.
+
+###########################################################
+
 FROM centos:6
 
 MAINTAINER APEL Administrator <apel-admins@stfc.ac.uk>

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 #   from within the container.)
 #
 # It has been placed in the repository root to allow for future
-# docker images to built 'commit by commit' from the exact
+# docker images to be built 'commit by commit' from the exact
 # state of the source in the repository. At the moment, it is 
 # limited to tagged versions that have RPMs, as that is the 
 # only way to install APEL.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+FROM centos:6
+
+MAINTAINER APEL Administrator <apel-admins@stfc.ac.uk>
+
+# Add EPEL repo so we can get pip
+RUN rpm -ivh http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+
+# Install tools needed to get RPMs from GitHub
+# Install python tools
+# Install mysql
+# Install cron
+# Install APEL requirements
+RUN yum -y install wget unzip python-pip python-devel mysql mysql-devel gcc cronie python-iso8601 python-ldap
+
+# Get APEL 1.6.0 codebase
+# In future, we maybe be able to run python setup.py install instead
+# and build a docker image based on the exact state of the
+# repository branch being built
+RUN wget https://github.com/apel/apel/releases/download/1.6.0-1/apel-lib-1.6.0-1.el6.noarch.rpm
+RUN wget https://github.com/apel/apel/releases/download/1.6.0-1/apel-server-1.6.0-1.el6.noarch.rpm
+
+# Install APEL code base from above RPMs
+# Use --nodeps because we dont need the ssm
+RUN rpm -i apel-lib-1.6.0-1.el6.noarch.rpm --nodeps
+RUN rpm -i apel-server-1.6.0-1.el6.noarch.rpm --nodeps
+
+# Install APEL REST requirements
+# python-daemon is sperately installed because it's
+# not a hard requiremnt of APEL (ie it's
+# not in requirements.txt, but in this case it is needed)
+COPY requirements.txt /root/requirements.txt
+RUN pip install -r /root/requirements.txt
+RUN pip install python-daemon
+RUN rm /root/requirements.txt
+
+# Register the cloud loader as a service
+COPY scripts/apeldbloader-cloud /etc/init.d/apeldbloader-cloud
+
+# Copy the script the cron job runs
+COPY scripts/run_cloud_summariser.sh /usr/bin/run_cloud_summariser.sh
+
+# Make cloud log and run directory
+RUN mkdir /var/log/cloud
+RUN mkdir /var/run/cloud
+
+# Make the apel user own those directories
+RUN chown apel /var/log/cloud
+RUN chown apel /var/run/cloud
+
+# Make cloud spool dir
+RUN mkdir -p /var/spool/apel/cloud/
+
+COPY docker/run_on_entry.sh /root/run_on_entry.sh
+
+ENTRYPOINT /root/run_on_entry.sh

--- a/docker/run_on_entry.sh
+++ b/docker/run_on_entry.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# start cron
+service crond start
+
+# start the loader service
+service apeldbloader-cloud start
+
+#keep docker running
+while true
+do
+  sleep 1
+done
+

--- a/docker/run_on_entry.sh
+++ b/docker/run_on_entry.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 # This file is run as process 1 by instances of the docker container
 # it starts:
-# - crond, to allow the periodic running of the summariser
 # - the cloud loader, as we want to start loadig as soon as the
 #   container is up (rather than waiting for the first summariser run)
+# - crond, to allow the periodic running of the summariser
 #
 # It then goes into an infinite loop as docker entrypoints have to
 # not terminate to keep the container alive
 
-# start cron
-service crond start
-
 # start the loader service
 service apeldbloader-cloud start
+
+# start cron
+service crond start
 
 #keep docker running
 while true

--- a/docker/run_on_entry.sh
+++ b/docker/run_on_entry.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# This file is run as process 1 by instances of the docker container
+# it starts:
+# - crond, to allow the periodic running of the summariser
+# - the cloud loader, as we want to start loadig as soon as the
+#   container is up (rather than waiting for the first summariser run)
+#
+# It then goes into an infinite loop as docker entrypoints have to
+# not terminate to keep the container alive
 
 # start cron
 service crond start

--- a/docker/run_on_entry.sh
+++ b/docker/run_on_entry.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# This file is run as process 1 by instances of the docker container
-# it starts:
+# This file is run as process 1 by instances of the docker container.
+# It starts:
 # - the cloud loader, as we want to start loadig as soon as the
 #   container is up (rather than waiting for the first summariser run)
 # - crond, to allow the periodic running of the summariser
 #
-# It then goes into an infinite loop as docker entrypoints have to
+# It then goes into an infinite loop as Docker entrypoints have to
 # not terminate to keep the container alive
 
 # start the loader service

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,17 @@
+# Scripts included for the Docker image
+
+The following files are present in this directory for the purposes of the Docker image, as they are common to all instances of the APEL cloud server.
+
+* `run_cloud_summariser.sh` 
+* `apeldbloader-cloud`
+
+They could also be included in Server RPMs in the future, but are not at the moment, so have been included here (rather than the docker directory, which is reserved for files only relevant to the Docker image)
+
+## run_cloud_summariser.sh
+
+This script runs the summariser in a safe way, by switching off the cloud loader to ensure there are no writes to the database while summarising.
+## apeldbloader-cloud
+
+This init script allows the Cloud Loader to be started/stopped with the `service` command. It differs from the more generic `dbld` also included in this directory, as it initiates a specific instance of a database loader, i.e. the Cloud Loader.
+
+

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,11 +5,12 @@ The following files are present in this directory for the purposes of the Docker
 * `run_cloud_summariser.sh` 
 * `apeldbloader-cloud`
 
-They could also be included in Server RPMs in the future, but are not at the moment, so have been included here (rather than the docker directory, which is reserved for files only relevant to the Docker image)
+They could also be included in Server RPMs in the future, but are not at the moment, so have been included here (rather than the docker directory, which is reserved for files only relevant to the Docker image).
 
 ## run_cloud_summariser.sh
 
 This script runs the summariser in a safe way, by switching off the cloud loader to ensure there are no writes to the database while summarising.
+
 ## apeldbloader-cloud
 
 This init script allows the Cloud Loader to be started/stopped with the `service` command. It differs from the more generic `dbld` also included in this directory, as it initiates a specific instance of a database loader, i.e. the Cloud Loader.

--- a/scripts/apeldbloader-cloud
+++ b/scripts/apeldbloader-cloud
@@ -1,9 +1,9 @@
 #!/bin/sh
 #
-# Startup script for cloud APEL cloud
+# Startup script for APEL cloud
 #
 # chkconfig: 2345 95 05
-# description: APEL dbloader daemon for cloud
+# description: APEL dbloader daemon init script for cloud loader
 # config: /etc/apel/cloudloader.cfg
 # pidfile: /var/run/apel/cloudloader.pid
 

--- a/scripts/apeldbloader-cloud
+++ b/scripts/apeldbloader-cloud
@@ -1,0 +1,64 @@
+#!/bin/sh
+#
+# Startup script for cloud APEL cloud
+#
+# chkconfig: 2345 95 05
+# description: APEL dbloader daemon for cloud
+# config: /etc/apel/cloudloader.cfg
+# pidfile: /var/run/apel/cloudloader.pid
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+user="root"
+prog="apeldbloader"
+dbconf="/etc/apel/clouddb.cfg"
+conf="/etc/apel/cloudloader.cfg"
+PIDFILE=/var/run/cloud/cloudloader.pid
+
+start() {
+    echo -n $"Starting $prog:"
+    su $user -c "python /usr/bin/$prog -d $dbconf -c $conf"
+    RETVAL=$?
+    echo
+}
+
+stop() {
+    echo -n $"Stopping $prog:"
+    if [ -f $PIDFILE ]; then
+        kill `cat $PIDFILE`
+        RETVAL=$?
+    else
+        echo "Pidfile not found."
+        RETVAL=1
+    fi
+    echo
+}
+
+case "$1" in
+        start)
+            start
+            ;;
+
+        stop)
+            stop
+            ;;
+
+        status)
+            status -p $PIDFILE $prog
+            RETVAL=$?
+            ;;
+
+        restart)
+            stop
+            start
+            ;;
+
+        *)
+            echo $"Usage: $0 {start|stop|restart|status}"
+            exit 1
+
+esac
+
+exit $RETVAL
+

--- a/scripts/run_cloud_summariser.sh
+++ b/scripts/run_cloud_summariser.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# This script runs the summariser in a safe way, by 
+# switching off the cloud loader to ensure there
+# are no writes to the database while summarising.
+
 # Stop the dbloader
 /sbin/service apeldbloader-cloud stop
 

--- a/scripts/run_cloud_summariser.sh
+++ b/scripts/run_cloud_summariser.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Stop the dbloader
+/sbin/service apeldbloader-cloud stop
+
+# Wait to ensure dbloader has stopped
+sleep 5
+
+# Run the summariser
+python /usr/bin/apelsummariser -d /etc/apel/clouddb.cfg -c /etc/apel/cloudsummariser.cfg
+
+# Wait to ensure summariser has stopped
+sleep 5
+
+# Start the dbloader
+/sbin/service apeldbloader-cloud start
+


### PR DESCRIPTION
This PR will allow a APEL 1.6.0 (and future tagged versions with RPMs) Cloud Accounting Docker Image to be built. The primary use case at the moment would be the Indigo DataCloud project, using a separate image for the APEL Server and APEL REST interface to allow for separate scaling of the REST interface.

It adds files needed in every instance of the image, added under `scripts/` and a Dockerfile to do the build.

cron jobs needed to run the summariser should be mounted into `/etc/cron.d/`.

